### PR TITLE
Subtree Nodes

### DIFF
--- a/BehaviorTree.cs
+++ b/BehaviorTree.cs
@@ -9,19 +9,19 @@ namespace BehaviorTree
 	{
 		public TreeNode root;
 
-		private Subtree _subtree;
+		private ExecutionStack _executionStack;
 
 		public List<EditorData> _editorData = new List<EditorData>();
 
 		public void Init( Hashtable data )
 		{
-			_subtree = new Subtree( root );
-			_subtree.Start( data );
+			_executionStack = new ExecutionStack( root );
+			_executionStack.Start( data );
 		}
 
 		public NodeStatus Tick()
 		{
-			return _subtree.Tick();
+			return _executionStack.Tick();
 		}
 	}
 
@@ -32,14 +32,14 @@ namespace BehaviorTree
 	// execution it passes the return value up the stack until the stack
 	// is emptied or a node pushes more children on (signified by the
 	// RUNNING_CHILDREN status).
-	public class Subtree
+	public class ExecutionStack
 	{
 		private TreeNode _root;
 
 		private Hashtable _data;
 		private Stack<TreeNode> _executionStack = new Stack<TreeNode>();
 
-		public Subtree( TreeNode root )
+		public ExecutionStack( TreeNode root )
 		{
 			this._root = root;
 		}

--- a/BehaviorTreeEditor.cs
+++ b/BehaviorTreeEditor.cs
@@ -196,7 +196,7 @@ namespace BehaviorTree
 		}
 
 		#region GUI Helpers
-		public Type CreateNodeTypeSelector( TreeNode node )
+		public Type CreateNodeTypeDropdown( TreeNode node )
 		{
 			int selectedType = ( node != null ? Array.IndexOf<Type>( nodeTypes, node.GetType() ) : Array.IndexOf<Type>( nodeTypes, typeof( NullNode ) ) );
 			Rect rect = new Rect( 0, 0, _nodeWidth - 40.0f, 20.0f );
@@ -224,7 +224,7 @@ namespace BehaviorTree
 			EditorData nodeData = _editorData[id];
 			TreeNode node = nodeData.node;
 
-			Type selectedType = CreateNodeTypeSelector( node );
+			Type selectedType = CreateNodeTypeDropdown( node );
 			if ( selectedType != node.GetType() )
 			{
 				ReplaceNode( nodeData, selectedType );

--- a/BehaviorTreeEditor.cs
+++ b/BehaviorTreeEditor.cs
@@ -17,6 +17,19 @@ namespace BehaviorTree
 		private BehaviorTree _behaviorTree;
 		private Dictionary<int, EditorData> _editorData = new Dictionary<int, EditorData>();
 
+		// Default settings.
+		private const float _nodeWidth = 200.0f;
+		private const float _nodeHeight = 100.0f;
+
+		// Decorator Settings
+		private const float _decoratorHeight = 20;
+
+		// Compositor Settings
+		private const float _compositorHeight = 50;
+
+		// Leaf settings.
+		private const float _leafHeight = 200.0f;
+
 		/**
 		 * @brief Add a menu item in the editor for creating new behavior tree assets.
 		 *
@@ -31,10 +44,19 @@ namespace BehaviorTree
 		[MenuItem( "Assets/Create/Behavior Tree" )]
 		public static void CreateBehaviorTreeAsset()
 		{
+			// Create behavior tree asset.
 			BehaviorTree behaviorTreeAsset = ScriptableObject.CreateInstance<BehaviorTree>();
 			AssetDatabase.CreateAsset( behaviorTreeAsset, "Assets/NewBehaviorTree.asset" );
-			AssetDatabase.SaveAssets();
 
+			// Add root node to behavior tree.
+			TreeNode newNode = (TreeNode)ScriptableObject.CreateInstance( typeof( NullNode ) );
+			newNode.id = newNode.GetInstanceID(); // generate a unique ID for the node.
+			behaviorTreeAsset._editorData.Add( new EditorData( newNode, null ) );
+			behaviorTreeAsset.root = newNode;
+			AssetDatabase.AddObjectToAsset( newNode, behaviorTreeAsset );
+
+			// Set asset as the active object.
+			AssetDatabase.SaveAssets();
 			EditorUtility.FocusProjectWindow();
 			Selection.activeObject = behaviorTreeAsset;
 		}
@@ -67,18 +89,11 @@ namespace BehaviorTree
 						typeof( BehaviorTree ),
 						false );
 
-				CreateTypeLists();
-
 				// only draw editor if a behavior tree is selected
 				if ( _behaviorTree )
 				{
-					// super hacky thing
-					if ( !_behaviorTree.root )
-					{
-						Debug.Log( "Behavior tree root doesn't exist, creating a new one." );
-						_behaviorTree.root = CreateNodeWithoutParent( typeof( NullNode ) );
-					}
-
+					// Perform initial setup.
+					CreateTypeLists();
 					BuildEditorData();
 
 					CreateGUI();
@@ -105,46 +120,58 @@ namespace BehaviorTree
 				return;
 			}
 
-			EditorData nodeData = _editorData[node.id]; // TODO: Crash here after the editor resets.
-
-			// draw window
-			Rect resultRect = GUI.Window( nodeData.id, nodeData.nodeRect, DrawNodeWindow, DisplayName( node.ToString() ) );
-			if ( resultRect != nodeData.nodeRect )
-			{
-				nodeData.nodeRect = resultRect;
-				EditorUtility.SetDirty( _behaviorTree );
-			}
-
-			// handle children
+			// Handle children.
 			if ( node is Decorator )
 			{
-				Decorator decorator = (Decorator)node;
-			
-				// ensure that the node has a child
-				if ( !decorator._child )
-				{
-					decorator._child = CreateNodeWithParent( typeof( NullNode ), decorator );
-				}
-
-				EditorData childData = _editorData[decorator._child.id];
-
-				// handle drawing the child
-				DrawNodeCurve( nodeData.nodeRect, childData.nodeRect );
-				DrawNode( decorator._child );
+				DrawDecorator( (Decorator)node );
 			}
 			else if ( node is Compositor )
 			{
-				Compositor compositor = (Compositor)node;
-
-				foreach ( TreeNode child in compositor._children )
-				{
-					EditorData childData = _editorData[child.id];
-
-					// handle drawing child
-					DrawNodeCurve( nodeData.nodeRect, childData.nodeRect );
-					DrawNode( child );
-				}
+				DrawCompositor( (Compositor)node );
 			}
+			else
+			{
+				DrawLeaf( (LeafNode)node );
+			}
+		}
+
+		void DrawDecorator( Decorator decorator )
+		{
+			EditorData nodeData = _editorData[decorator.id];
+			CreateNodeWindow( nodeData, _nodeWidth, _decoratorHeight );
+
+			// ensure that the node has a child
+			if ( !decorator._child )
+			{
+				decorator._child = CreateNodeWithParent( typeof( NullNode ), decorator );
+			}
+
+			EditorData childData = _editorData[decorator._child.id];
+
+			// handle drawing the child
+			DrawNodeCurve( nodeData.nodeRect, childData.nodeRect );
+			DrawNode( decorator._child );
+		}
+
+		void DrawCompositor( Compositor compositor )
+		{
+			EditorData nodeData = _editorData[compositor.id];
+			CreateNodeWindow( nodeData, _nodeWidth, _compositorHeight );
+
+			foreach ( TreeNode child in compositor._children )
+			{
+				EditorData childData = _editorData[child.id];
+
+				// handle drawing child
+				DrawNodeCurve( nodeData.nodeRect, childData.nodeRect );
+				DrawNode( child );
+			}
+		}
+
+		void DrawLeaf( LeafNode leaf )
+		{
+			EditorData nodeData = _editorData[leaf.id];
+			CreateNodeWindow( nodeData, _nodeWidth, _leafHeight );
 		}
 
 		static string DisplayName( string name )
@@ -157,6 +184,40 @@ namespace BehaviorTree
 			return name;
 		}
 
+		void CreateTypeLists()
+		{
+			// get list of possible node types
+			// i.e., all types that extend TreeNode and are not abstract
+			nodeTypes = typeof( TreeNode ).Assembly.GetTypes()
+					.Where( type => type.IsSubclassOf( typeof( TreeNode ) ) && !type.IsAbstract ).ToArray<Type>();
+			nodeTypeNames = Array.ConvertAll<Type, String>( nodeTypes,
+				new Converter<Type, String> (
+					delegate( Type type ) { return DisplayName( type.ToString() ); } ) );
+		}
+
+		#region GUI Helpers
+		public Type CreateNodeTypeSelector( TreeNode node )
+		{
+			int selectedType = ( node != null ? Array.IndexOf<Type>( nodeTypes, node.GetType() ) : Array.IndexOf<Type>( nodeTypes, typeof( NullNode ) ) );
+			Rect rect = new Rect( 0, 0, _nodeWidth - 40.0f, 20.0f );
+			selectedType = EditorGUI.Popup( rect, selectedType, nodeTypeNames );
+			return nodeTypes[selectedType];
+		}
+
+		void CreateNodeWindow( EditorData nodeData, float width, float height )
+		{
+			nodeData.nodeRect.width = width;
+			nodeData.nodeRect.height = height;
+			Rect resultRect = GUI.Window( nodeData.id, nodeData.nodeRect, DrawNodeWindow, "" );
+
+			// If the node was moved, save the change and mark the asset as dirty.
+			if ( resultRect != nodeData.nodeRect )
+			{
+				nodeData.nodeRect = resultRect;
+				EditorUtility.SetDirty( _behaviorTree );
+			}
+		}
+
 		void DrawNodeWindow( int id )
 		{
 			// Get EditorNode
@@ -167,52 +228,28 @@ namespace BehaviorTree
 			if ( selectedType != node.GetType() )
 			{
 				ReplaceNode( nodeData, selectedType );
+				node = nodeData.node;
 			}
 
 			if ( node is Compositor )
 			{
 				Compositor compositor = (Compositor)node;
 
-				Rect rect = new Rect( 0, 30, nodeData.nodeRect.width, 20 );
+				Rect rect = new Rect( 0, 20, _nodeWidth, 20 );
 				if ( GUI.Button( rect, "Add Child" ) )
 				{
 					TreeNode childNode = CreateNodeWithParent( typeof( NullNode ), compositor );
 					compositor._children.Add( childNode );
 				}
 			}
+			else if ( node is LeafNode )
+			{
+				Editor editor = Editor.CreateEditor( node );
+				editor.OnInspectorGUI();
+			}
 
 			// Drag window last because otherwise you can't click on things
 			GUI.DragWindow();
-		}
-
-		void ReplaceNode( EditorData nodeData, Type newType )
-		{
-			DeleteNode( nodeData.node );
-			CreateNodeWithExistingData( newType, nodeData );
-
-			// Update parent's reference to the node.
-			if ( nodeData.parent )
-			{
-				if ( nodeData.parent is Decorator )
-				{
-					Decorator parentDecorator = (Decorator)nodeData.parent;
-					parentDecorator._child = nodeData.node;
-				}
-				else if ( nodeData.parent is Compositor )
-				{
-					Compositor parentCompositor = (Compositor)nodeData.parent;
-					parentCompositor._children[nodeData.parentIndex] = nodeData.node;
-				}
-				else
-				{
-					Debug.LogError( "Parent node is neither a Decorator nor a Compositor!" );
-				}
-			}
-			else
-			{
-				// Node is root node.
-				_behaviorTree.root = nodeData.node;
-			}
 		}
 
 		void DrawNodeCurve( Rect start, Rect end )
@@ -231,58 +268,9 @@ namespace BehaviorTree
 
 			Handles.DrawBezier( startPos, endPos, startTan, endTan, Color.black, null, 1 );
 		}
+		#endregion
 
-		void CreateTypeLists()
-		{
-			// get list of possible node types
-			// i.e., all types that extend TreeNode and are not abstract
-			nodeTypes = typeof( TreeNode ).Assembly.GetTypes()
-					.Where( type => type.IsSubclassOf( typeof( TreeNode ) ) && !type.IsAbstract ).ToArray<Type>();
-			nodeTypeNames = Array.ConvertAll<Type, String>( nodeTypes,
-				new Converter<Type, String> (
-					delegate( Type type ) { return DisplayName( type.ToString() ); } ) );
-		}
-
-		public void DeleteNode( TreeNode node )
-		{
-			if ( node is Decorator )
-			{
-				DeleteNode( ( (Decorator)node )._child );
-			}
-			else if ( node is Compositor )
-			{
-				foreach ( TreeNode child in ( (Compositor)node )._children )
-				{
-					DeleteNode( child );
-				}
-			}
-
-			// Remove the editor data from the list held by the behavior tree.
-			_behaviorTree._editorData.Remove( _editorData[node.id] );
-
-			// Remove the data from the local dict.
-			_editorData.Remove( node.id );
-
-			DestroyImmediate( node, true );
-		}
-
-		public Type CreateNodeTypeSelector( TreeNode node )
-		{
-			int selectedType = ( node != null ? Array.IndexOf<Type>( nodeTypes, node.GetType() ) : Array.IndexOf<Type>( nodeTypes, typeof( NullNode ) ) );
-			Rect rect = new Rect( 0, 0, 100, 20 );
-			selectedType = EditorGUI.Popup( rect, selectedType, nodeTypeNames );
-			return nodeTypes[selectedType];
-		}
-
-		public bool CreateChildrenFoldout( TreeNode node, int height )
-		{
-			EditorData nodeData = _editorData[node.id];
-
-			Rect rect = new Rect( 0, 0, 100, 20 );
-			nodeData.foldout = EditorGUI.Foldout( rect, nodeData.foldout, "children", true );
-			return nodeData.foldout;
-		}
-
+		#region Create and Destroy Nodes
 		// NOTE: Do NOT call this directly! It's a only helper function for the other CreateNode...() methods.
 		public TreeNode CreateNode( Type nodeType )
 		{
@@ -329,14 +317,60 @@ namespace BehaviorTree
 
 			return newNode;
 		}
-
-		public TreeNode nullNode
+		
+		public void DeleteNode( TreeNode node )
 		{
-			get
+			if ( node is Decorator )
 			{
-				return CreateNodeWithoutParent( typeof( NullNode ) );
+				DeleteNode( ( (Decorator)node )._child );
+			}
+			else if ( node is Compositor )
+			{
+				foreach ( TreeNode child in ( (Compositor)node )._children )
+				{
+					DeleteNode( child );
+				}
+			}
+
+			// Remove the editor data from the list held by the behavior tree.
+			_behaviorTree._editorData.Remove( _editorData[node.id] );
+
+			// Remove the data from the local dict.
+			_editorData.Remove( node.id );
+
+			DestroyImmediate( node, true );
+		}
+
+		void ReplaceNode( EditorData nodeData, Type newType )
+		{
+			DeleteNode( nodeData.node );
+			CreateNodeWithExistingData( newType, nodeData );
+
+			// Update parent's reference to the node.
+			if ( nodeData.parent )
+			{
+				if ( nodeData.parent is Decorator )
+				{
+					Decorator parentDecorator = (Decorator)nodeData.parent;
+					parentDecorator._child = nodeData.node;
+				}
+				else if ( nodeData.parent is Compositor )
+				{
+					Compositor parentCompositor = (Compositor)nodeData.parent;
+					parentCompositor._children[nodeData.parentIndex] = nodeData.node;
+				}
+				else
+				{
+					Debug.LogError( "Parent node is neither a Decorator nor a Compositor!" );
+				}
+			}
+			else
+			{
+				// Node is root node.
+				_behaviorTree.root = nodeData.node;
 			}
 		}
+		#endregion
 
 		public static BehaviorTree CloneTree( BehaviorTree behaviorTree )
 		{

--- a/BehaviorTreeEditor.cs
+++ b/BehaviorTreeEditor.cs
@@ -192,7 +192,21 @@ namespace BehaviorTree
 					.Where( type => type.IsSubclassOf( typeof( TreeNode ) ) && !type.IsAbstract ).ToArray<Type>();
 			nodeTypeNames = Array.ConvertAll<Type, String>( nodeTypes,
 				new Converter<Type, String> (
-					delegate( Type type ) { return type.Name; } ) );
+					delegate( Type type )
+					{
+						if ( type.IsSubclassOf( typeof( Decorator ) ) )
+						{
+							return "Decorators/" + type.Name;
+						}
+						else if ( type.IsSubclassOf( typeof( Compositor ) ) )
+						{
+							return "Compositors/" + type.Name;
+						}
+						else
+						{
+							return "Leaves/" + type.Name;
+						}
+					} ) );
 		}
 
 		#region GUI Helpers

--- a/BehaviorTreeEditor.cs
+++ b/BehaviorTreeEditor.cs
@@ -268,19 +268,22 @@ namespace BehaviorTree
 
 		void DrawNodeCurve( Rect start, Rect end )
 		{
+			float dist = Vector2.Distance( start.position, end.position );
+			float curvePower = dist * 0.25f;
+
 			Vector3 startPos = new Vector3( start.x + start.width * 0.5f, start.y + start.height, 0 );
 			Vector3 endPos = new Vector3( end.x + end.width * 0.5f, end.y, 0 );
-			Vector3 startTan = startPos + Vector3.up * 50;
-			Vector3 endTan = endPos + Vector3.down * 50;
+			Vector3 startTan = startPos + Vector3.up * curvePower;
+			Vector3 endTan = endPos + Vector3.down * curvePower;
 			Color shadowCol = new Color( 0, 0, 0, 0.06f );
 		
-			// Draw a shadow
+			// Draw a shadow.
 			for ( int i = 0; i < 3; i++ )
 			{
 				Handles.DrawBezier( startPos, endPos, startTan, endTan, shadowCol, null, ( i + 1 ) * 5 );
 			}
 
-			Handles.DrawBezier( startPos, endPos, startTan, endTan, Color.black, null, 1 );
+			Handles.DrawBezier( startPos, endPos, startTan, endTan, Color.black, null, 2 );
 		}
 		#endregion
 

--- a/Nodes/Leaves/Subtree.cs
+++ b/Nodes/Leaves/Subtree.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections;
+
+namespace BehaviorTree
+{
+	class Subtree : LeafNode
+	{
+		public BehaviorTree behaviorTree;
+
+		public override void InitSelf( Hashtable data )
+		{
+			behaviorTree = BehaviorTreeEditor.CloneTree( behaviorTree );
+			behaviorTree.Init( data );
+		}
+
+		public override NodeStatus TickSelf()
+		{
+			return behaviorTree.Tick();
+		}
+	}
+}

--- a/Nodes/Leaves/Subtree.cs.meta
+++ b/Nodes/Leaves/Subtree.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 242a99e92e6752649a4f33c219a21639
+timeCreated: 1428014640
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Nodes/ParallelCompositors/SequenceParallel.cs
+++ b/Nodes/ParallelCompositors/SequenceParallel.cs
@@ -19,7 +19,7 @@ namespace BehaviorTree
 			DebugUtils.Assert( childStatus == NodeStatus.SUCCESS );
 
 			int successes = 0;
-			foreach ( Subtree subtree in _subtrees )
+			foreach ( ExecutionStack subtree in _subtrees )
 			{
 				switch ( subtree.Tick() )
 				{

--- a/Nodes/TreeNode.cs
+++ b/Nodes/TreeNode.cs
@@ -14,6 +14,7 @@ namespace BehaviorTree
 
 	public abstract class TreeNode : ScriptableObject
 	{
+		[HideInInspector]
 		public int id;
 
 		public abstract TreeNode Init( Hashtable data );
@@ -43,7 +44,7 @@ namespace BehaviorTree
 
 	public abstract class Parallel : Compositor
 	{
-		public List<Subtree> _subtrees = new List<Subtree>();
+		public List<ExecutionStack> _subtrees = new List<ExecutionStack>();
 
 		public override TreeNode Init( Hashtable data )
 		{
@@ -51,15 +52,15 @@ namespace BehaviorTree
 			{
 				// If we don't have the right number of subtrees,
 				// recreate the subtree list.
-				_subtrees = new List<Subtree>();
+				_subtrees = new List<ExecutionStack>();
 				foreach ( TreeNode child in _children )
 				{
-					Subtree subtree = new Subtree( child );
+					ExecutionStack subtree = new ExecutionStack( child );
 					_subtrees.Add( subtree );
 				}
 			}
 
-			foreach ( Subtree subtree in _subtrees )
+			foreach ( ExecutionStack subtree in _subtrees )
 			{
 				subtree.Start( data );
 			}


### PR DESCRIPTION
- Adds new `Subtree` leaf node which ticks into another behavior tree.
- Leaf nodes now allow for editing of instance data.
- Adds subheadings to the node type dropdown so that compositors, decorators, and leaves are grouped under separate headings.
- Changed the way nodes are drawn so that compositors, decorators, and leaves are handled differently to allow them to be displayed at different sizes.
- Tweaked the way that the lines between nodes are drawn so that the curves aren't so steep when nodes are close together. Also made the lines darker since they looked bad before.
